### PR TITLE
support Go version 1.13+ only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: go
 go_import_path: github.com/kazukousen/gouml
 
 go:
-  - 1.11.x
-  - 1.12.x
+  - 1.13.x
 
 script:
   go test -race ./...


### PR DESCRIPTION
Hi users, Do you need support for 1.11 and 1.12 ?